### PR TITLE
Hide expired user entries when a list of vacations has been requested

### DIFF
--- a/core/src/main/java/rs/kunpero/vacation/service/VacationService.java
+++ b/core/src/main/java/rs/kunpero/vacation/service/VacationService.java
@@ -78,6 +78,7 @@ public class VacationService {
 
     public ShowVacationInfoResponseDto showVacationInfo(ShowVacationInfoRequestDto request) {
         List<VacationInfo> vacationInfoList = vacationInfoRepository.findByUserIdAndTeamId(request.getUserId(), request.getTeamId());
+        vacationInfoList.removeIf(v -> v.getDateTo().isBefore(LocalDate.now()));
         return new ShowVacationInfoResponseDto()
                 .setVacationInfoList(buildVacationInfoDtoListForUser(vacationInfoList));
     }


### PR DESCRIPTION
That's a minimal fix, ofc. We could invalidate entries in database, or even clean them up periodically.